### PR TITLE
Remove slimming of the smtp host

### DIFF
--- a/EventListener/ConfigSubscriber.php
+++ b/EventListener/ConfigSubscriber.php
@@ -48,14 +48,7 @@ class ConfigSubscriber implements EventSubscriberInterface
 
     private function getEmailDomain($host)
     {
-        $count = \substr_count($host, '.');
-        if (1 == $count) {
-            return $host;
-        }
-
-        $parts = explode('.', $host, 2);
-
-        return $parts[1];
+        return $host;
     }
 
     public function __construct(CoreParametersHelper $coreParametersHelper)


### PR DESCRIPTION
We removed the slimming because we do not need it anymore and its causing issues when we are actually trying to send emails from subdomain.